### PR TITLE
fix: :hammer: Fixed SSH secret name in deploy workflow

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         host: ${{ secrets.EC2_HOST }}
         username: ec2-user
-        key: ${{ secrets.EC2_ssH_KEY }}
+        key: ${{ secrets.EC2_SSH_KEY }}
         script: |
           sudo cp -r /home/ec2-user/web_interface/* /var/www/html/
           sudo systemctl restart httpd


### PR DESCRIPTION
An error was detected in the secret name:  

➡️ EC2_ssH_KEY 
➡️ EC2_SSH_KEY  

With this fix, the workflow can successfully authenticate to the EC2 server and complete the deployment.